### PR TITLE
Add forward separator support to preserve forwarded messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Add to your `claude_desktop_config.json`:
 - `NOTMUCH_SYNC_SCRIPT`: Path to a script for synchronizing emails (optional)
 - `LOG_FILE_PATH`: Path for logging file (optional)
 - `DRAFT_DIR`: Directory for storing email drafts (optional, defaults to /tmp/mcp-notmuch-sendmail)
+- `NOTMUCH_FORWARD_SEPARATORS`: Pipe-separated list of forward indicators - when these are detected, the forwarded content is preserved instead of being filtered (optional)
 
 ## API
 
@@ -160,6 +161,20 @@ Il.*ha scritto:|Da:|Inviato|A:|Oggetto:|Data:|Cc:|Cordiali saluti|Inviato da
 ```
 
 Note: Use | (pipe) to separate patterns. These are simplified patterns derived from common email clients - you may need to adjust them based on your specific needs.
+
+## Forward Separators
+
+The `NOTMUCH_FORWARD_SEPARATORS` environment variable helps preserve forwarded messages that would otherwise be filtered out by reply separators. When these patterns are detected, the content that follows is kept instead of removed.
+
+### Danish Configuration
+
+For Danish email clients, use this configuration:
+
+```
+NOTMUCH_FORWARD_SEPARATORS="Begin forwarded message:|---------- Forwarded message ----------|-----Original Message-----|Videresendt besked:|---------- Videresendt meddelelse ----------|-----Oprindelig meddelelse-----|Start på videresendt besked:"
+```
+
+This includes both English and Danish forward indicators commonly used by email clients like Apple Mail, Gmail, and Outlook.
 
 ## Contributing
 

--- a/mcp_notmuch_sendmail/core.py
+++ b/mcp_notmuch_sendmail/core.py
@@ -8,6 +8,7 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).parent
 NOTMUCH_DATABASE_PATH = os.environ["NOTMUCH_DATABASE_PATH"]
 NOTMUCH_REPLY_SEPARATORS = list(os.environ["NOTMUCH_REPLY_SEPARATORS"].split("|"))
+NOTMUCH_FORWARD_SEPARATORS = list(os.environ.get("NOTMUCH_FORWARD_SEPARATORS", "").split("|")) if os.environ.get("NOTMUCH_FORWARD_SEPARATORS") else None
 SENDMAIL_FROM_EMAIL = os.environ["SENDMAIL_FROM_EMAIL"]
 SENDMAIL_EMAIL_SIGNATURE_HTML = os.environ.get("SENDMAIL_EMAIL_SIGNATURE_HTML", "")
 LOG_FILE_PATH = os.environ.get('LOG_FILE_PATH', False)

--- a/mcp_notmuch_sendmail/core.py
+++ b/mcp_notmuch_sendmail/core.py
@@ -7,8 +7,8 @@ from pathlib import Path
 ### Constants ###
 ROOT_DIR = Path(__file__).parent
 NOTMUCH_DATABASE_PATH = os.environ["NOTMUCH_DATABASE_PATH"]
-NOTMUCH_REPLY_SEPARATORS = list(os.environ["NOTMUCH_REPLY_SEPARATORS"].split("|"))
-NOTMUCH_FORWARD_SEPARATORS = list(os.environ.get("NOTMUCH_FORWARD_SEPARATORS", "").split("|")) if os.environ.get("NOTMUCH_FORWARD_SEPARATORS") else None
+NOTMUCH_REPLY_SEPARATORS = [sep for sep in os.environ["NOTMUCH_REPLY_SEPARATORS"].split("|") if sep.strip()]
+NOTMUCH_FORWARD_SEPARATORS = [sep for sep in os.environ.get("NOTMUCH_FORWARD_SEPARATORS", "").split("|") if sep.strip()] if os.environ.get("NOTMUCH_FORWARD_SEPARATORS") else None
 SENDMAIL_FROM_EMAIL = os.environ["SENDMAIL_FROM_EMAIL"]
 SENDMAIL_EMAIL_SIGNATURE_HTML = os.environ.get("SENDMAIL_EMAIL_SIGNATURE_HTML", "")
 LOG_FILE_PATH = os.environ.get('LOG_FILE_PATH', False)

--- a/mcp_notmuch_sendmail/notmuchlib.py
+++ b/mcp_notmuch_sendmail/notmuchlib.py
@@ -18,26 +18,45 @@ def message_to_text(message):
         return re.sub(r'(\n\s*){2,}', '\n\n', text)
 
     def extract_reply(text):
+        # First, check if there's a forwarded message to preserve
+        forwarded_content = None
+        if NOTMUCH_FORWARD_SEPARATORS:
+            lines = text.splitlines()
+            for i, line in enumerate(lines):
+                stripped_line = line.strip().lower()
+                unquoted_line = stripped_line.lstrip('> ')
+                
+                for forward_separator in NOTMUCH_FORWARD_SEPARATORS:
+                    if forward_separator and (stripped_line.startswith(forward_separator.lower()) or 
+                                              unquoted_line.startswith(forward_separator.lower())):
+                        # Found a forward separator - extract everything from this line onwards
+                        forwarded_content = "\n".join(lines[i:])
+                        # Remove the forwarded part from the original text
+                        text = "\n".join(lines[:i])
+                        break
+                if forwarded_content:
+                    break
+        
+        # Now process the text normally for reply separators
         result = []
         for line in text.splitlines():
-            # Strip whitespace for comparison but keep original line
             stripped_line = line.strip().lower()
-            
-            # Check if this line is a forward separator - if so, keep everything
-            if NOTMUCH_FORWARD_SEPARATORS:
-                for forward_separator in NOTMUCH_FORWARD_SEPARATORS:
-                    if forward_separator and stripped_line.startswith(forward_separator.lower()):
-                        # Keep everything from here on (it's a forwarded message)
-                        result.append(line)
-                        remaining_lines = text.split(line, 1)[1].splitlines()
-                        result.extend(remaining_lines)
-                        return "\n".join(result).strip()
+            unquoted_line = stripped_line.lstrip('> ')
             
             # Check if this line is a reply separator - if so, stop here
             for reply_separator in NOTMUCH_REPLY_SEPARATORS:
-                if stripped_line.startswith(reply_separator.lower()):
+                if reply_separator and (stripped_line.startswith(reply_separator.lower()) or
+                                        unquoted_line.startswith(reply_separator.lower())):
+                    # Add the forwarded content back at the end if we found any
+                    if forwarded_content:
+                        return "\n".join(result).strip() + "\n\n" + forwarded_content
                     return "\n".join(result).strip()
             result.append(line)
+        
+        # If we didn't hit any reply separators, return the original text
+        # (with forwarded content appended if found)
+        if forwarded_content:
+            return text.strip() + "\n\n" + forwarded_content
         return text
 
     def decode_qp(text):

--- a/mcp_notmuch_sendmail/notmuchlib.py
+++ b/mcp_notmuch_sendmail/notmuchlib.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Dict, Optional
 import html2text
 from notmuch import Query, Database
-from mcp_notmuch_sendmail.core import ROOT_DIR, NOTMUCH_DATABASE_PATH, NOTMUCH_REPLY_SEPARATORS
+from mcp_notmuch_sendmail.core import ROOT_DIR, NOTMUCH_DATABASE_PATH, NOTMUCH_REPLY_SEPARATORS, NOTMUCH_FORWARD_SEPARATORS
 
 # Optional script to sync emails
 NOTMUCH_SYNC_SCRIPT = os.environ.get("NOTMUCH_SYNC_SCRIPT", None)
@@ -20,8 +20,19 @@ def message_to_text(message):
     def extract_reply(text):
         result = []
         for line in text.splitlines():
+            # Check if this line is a forward separator - if so, keep everything
+            if NOTMUCH_FORWARD_SEPARATORS:
+                for forward_separator in NOTMUCH_FORWARD_SEPARATORS:
+                    if forward_separator and line.lower().startswith(forward_separator.lower()):
+                        # Keep everything from here on (it's a forwarded message)
+                        result.append(line)
+                        remaining_lines = text.split(line, 1)[1].splitlines()
+                        result.extend(remaining_lines)
+                        return "\n".join(result).strip()
+            
+            # Check if this line is a reply separator - if so, stop here
             for reply_separator in NOTMUCH_REPLY_SEPARATORS:
-                if line.lower().startswith(reply_separator):
+                if line.lower().startswith(reply_separator.lower()):
                     return "\n".join(result).strip()
             result.append(line)
         return text

--- a/mcp_notmuch_sendmail/notmuchlib.py
+++ b/mcp_notmuch_sendmail/notmuchlib.py
@@ -20,10 +20,13 @@ def message_to_text(message):
     def extract_reply(text):
         result = []
         for line in text.splitlines():
+            # Strip whitespace for comparison but keep original line
+            stripped_line = line.strip().lower()
+            
             # Check if this line is a forward separator - if so, keep everything
             if NOTMUCH_FORWARD_SEPARATORS:
                 for forward_separator in NOTMUCH_FORWARD_SEPARATORS:
-                    if forward_separator and line.lower().startswith(forward_separator.lower()):
+                    if forward_separator and stripped_line.startswith(forward_separator.lower()):
                         # Keep everything from here on (it's a forwarded message)
                         result.append(line)
                         remaining_lines = text.split(line, 1)[1].splitlines()
@@ -32,7 +35,7 @@ def message_to_text(message):
             
             # Check if this line is a reply separator - if so, stop here
             for reply_separator in NOTMUCH_REPLY_SEPARATORS:
-                if line.lower().startswith(reply_separator.lower()):
+                if stripped_line.startswith(reply_separator.lower()):
                     return "\n".join(result).strip()
             result.append(line)
         return text

--- a/uv.lock
+++ b/uv.lock
@@ -281,7 +281,7 @@ cli = [
 
 [[package]]
 name = "mcp-notmuch-sendmail"
-version = "2025.4.9.91234"
+version = "2025.4.9.174710"
 source = { editable = "." }
 dependencies = [
     { name = "bs4" },


### PR DESCRIPTION
Adds NOTMUCH_FORWARD_SEPARATORS env var to preserve forwarded messages that would otherwise be cut off by reply separators.

Example:
```
NOTMUCH_FORWARD_SEPARATORS="Begin forwarded message: < /dev/null | ---------- Forwarded message ----------|Videresendt besked:"
```